### PR TITLE
Omit optional fields when null while decoding

### DIFF
--- a/jrec.cabal
+++ b/jrec.cabal
@@ -86,7 +86,8 @@ test-suite jrec-test
   import: library-common
   type: exitcode-stdio-1.0
   hs-source-dirs: test, src
-  main-is: Spec.hs 
+  main-is: Spec.hs
+  cpp-options: -DWITH_AESON
   build-depends:
     base,
     hspec,


### PR DESCRIPTION
Parse `{}` as a valid `Rec '[ "a" := Maybe Int ]` value `Rec ( #a := Nothing ) `