### PR TITLE
Update to work with 20.9 snapshot

### DIFF
--- a/jrec.cabal
+++ b/jrec.cabal
@@ -37,7 +37,7 @@ common library-common
   default-language:   Haskell2010
   build-depends:
       aeson
-    , base          >=4.13 && <4.15
+    , base          >=4.13 && <4.17
     , constraints
     , deepseq
     , generic-data


### PR DESCRIPTION
Updates base constraints and updates to use the newer aeson 'Key' type. This, unfortunately, is not backwards compatible.

Feel free to `#ifdef` the changes to compile with older snapshots.